### PR TITLE
CFX: Dropdown for varrule input

### DIFF
--- a/plugins/cfx_plugin.py
+++ b/plugins/cfx_plugin.py
@@ -4,7 +4,7 @@ import os
 import dash_bootstrap_components as dbc
 from dash import Input, Output, State, callback, dcc, html
 
-from plugins.cfx_utils import create_plot, find_mon_files
+from plugins.cfx_utils import create_plot, find_mon_files, get_varrule_choices
 from utils import is_debug
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,7 @@ def get_layout():
                  not found.
         """
 
+        varrule_choices = get_varrule_choices()
         mon_files = find_mon_files()
         if not mon_files:
             return html.Div(
@@ -93,11 +94,12 @@ def get_layout():
                     [
                         "Varrule to plot",
                         html.Br(),
-                        dcc.Input(
-                            id="varrule-input",
+                        dcc.Dropdown(
+                            id="varrule-dropdown",
+                            style={"width": "800px"},
+                            options=varrule_choices,
                             value="CATEGORY = USER POINT",
-                            type="text",
-                            style={"width": "400px"},
+                            clearable=False
                         ),
                     ],
                     style={"marginTop": 12},
@@ -114,7 +116,7 @@ def get_layout():
         [
             Input("button-reload", "n_clicks"),
             State("mon-dropdown", "value"),
-            State("varrule-input", "value"),
+            State("varrule-dropdown", "value"),
         ],
         prevent_initial_call=True,
     )
@@ -129,7 +131,7 @@ def get_layout():
         fig = create_plot(mon_file, varrule)
 
         if fig:
-            return dcc.Graph(figure=fig, id="graph")
+            return dcc.Loading(children=dcc.Graph(figure=fig, id="graph"), style={"display": "none"})
         else:
             return html.Div(
                 [

--- a/plugins/cfx_plugin.py
+++ b/plugins/cfx_plugin.py
@@ -131,7 +131,7 @@ def get_layout():
         fig = create_plot(mon_file, varrule)
 
         if fig:
-            return dcc.Loading(children=dcc.Graph(figure=fig, id="graph"), style={"display": "none"})
+            return dcc.Graph(figure=fig, id="graph")
         else:
             return html.Div(
                 [

--- a/plugins/cfx_utils.py
+++ b/plugins/cfx_utils.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import os
 import subprocess
 from io import StringIO
@@ -88,3 +89,44 @@ def create_plot(mon_file, varrule):
     fig.update_xaxes(range=[0.0, None], title=df.columns[0])
 
     return fig
+
+
+def get_varrule_choices():
+    """
+    Return possible choices for the 'varrule' command line parameter.
+    Extend the default choices by the values defined in the file ~/cfx_monitor.json if that file exists.
+    Example content for ~/cfx_monitor.json:
+    {"varrule_choices": ["CATEGORY = AAA, "CATEGORY = BBB"]}
+    """
+
+    choices = [
+        f"CATEGORY = {c}" for c in [
+            "COMBINED",
+            "FLOW",
+            "FORCE",
+            "IMBALANCE",
+            "MOMENT",
+            "RESIDUAL",
+            "SOURCE",
+            "USER POINT"
+        ]
+    ]
+
+    config_file = Path.home().joinpath('cfx_monitor.json')
+    if config_file.is_file():
+        with config_file.open('r') as file:
+            try:
+                data = json.load(file)
+            except json.decoder.JSONDecodeError:
+                data = {}
+        if ('varrule_choices' in data) and (isinstance(data['varrule_choices'], list)):
+            choices += data['varrule_choices']
+
+    choices = list(set(choices))
+    choices.sort()
+    return choices
+
+
+
+
+


### PR DESCRIPTION
Replace the text field by a dropdown for the varrule input of the CFX monitor.

The default choices can be extended by values defined in the file ~/cfx_monitor.json.
Example content for ~/cfx_monitor.json:
{"varrule_choices": ["CATEGORY = AAA, "CATEGORY = BBB"]}
